### PR TITLE
[bugfix] rule's global enable/disable state should be restored after …

### DIFF
--- a/test/rules/_integration/enable-disable/test.ts.lint
+++ b/test/rules/_integration/enable-disable/test.ts.lint
@@ -51,3 +51,10 @@ var AAAaA = 'test'
 
 /* tslint:disable:quotemark */
 var s = 'xxx';
+
+/* tslint:disable:quotemark */
+var s = 'xxx';
+/* tslint:disable-next-line:quotemark */
+var s = 'xxx';
+var s = 'xxx';
+


### PR DESCRIPTION
…local override

Before this PR a local (next-)line state change would ignore the global state:

```
    /* tslint:disable:quotemark */
    var s = 'xxx';
    /* tslint:disable-next-line:quotemark */
    var s = 'xxx';
    var s = 'xxx';  // <- this would have errored
```